### PR TITLE
Use steady/monotonic clock for the timers.

### DIFF
--- a/src/gui/Timer.h
+++ b/src/gui/Timer.h
@@ -3,15 +3,15 @@
 
 class Timer {
 public:
-    Timer() { clock_gettime(CLOCK_REALTIME, &beg_); }
+    Timer() { clock_gettime(CLOCK_MONOTONIC, &beg_); }
 
     double elapsed() {
-        clock_gettime(CLOCK_REALTIME, &end_);
+        clock_gettime(CLOCK_MONOTONIC, &end_);
         return end_.tv_sec - beg_.tv_sec +
                (end_.tv_nsec - beg_.tv_nsec) / 1000000000.;
     }
 
-    void reset() { clock_gettime(CLOCK_REALTIME, &beg_); }
+    void reset() { clock_gettime(CLOCK_MONOTONIC, &beg_); }
 
 private:
     timespec beg_, end_;


### PR DESCRIPTION
Since the time sync plugin can make the clock jump backwards, measuring elapsed time with the realtime clock is not reliable.
A common problem is the user setting the clock back 1 hour, due to DST changes: any notification processed while the clock jumps back will take one extra hour to expire.